### PR TITLE
chore: Add vng name to Name tag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ resource "spotinst_ocean_aws_launch_spec" "nodegroup" {
   # Required tags
   tags {
     key   = "Name"
-    value = "${var.cluster_name}-ocean-cluster-node"
+    value = "${var.cluster_name}-ocean-cluster-node-${var.name}"
   }
   tags {
     key   = "kubernetes.io/cluster/${var.cluster_name}"


### PR DESCRIPTION
## Motivation
I use this module to spin up VNGs in my account. This month I got a surprising bill and trying to asses my spending showed that most of it was tagged with the name `awesome-cluster-ocean-cluster-node` and I had a hard time navigating through my spending because of this hard limit in this module.

## Considiration
In the module's `main.tf` file, the tag has a comment above it saying `Name` is a required tag and has a set value to it. In the [Terraform provider documentation](https://registry.terraform.io/providers/spotinst/spotinst/latest/docs/resources/ocean_aws_launch_spec#tags) the `tags` key is listed as completely option. I don't know if there's anything behind the scenes in the VNG code that requires a set value for the `Name` tag so I added something which makes sense to me.

In case this isn't a viable solution, I'd be grateful if you could shed some light in to managing the names of my AWS EC2 instances.

## The solution
Appending the VNG name to the VNG's launch spec`Name` tag will help filter my spending.
 