### PR TITLE
Remove required tags to prevent duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-<a name="unreleased"></a>
-## [Unreleased]
+<a name="v0.4.2"></a>
+## [v0.4.2] (December 5, 2022)\
 
-<a name="v0.4.0"></a>
-## [v0.4.1] (October 31, 2022)
+- Remove required tags to prevent duplication
+
+<a name="v0.4.1"></a>
+## [v0.4.1] (October 31, 2022)\
 
 - Make tag name optional
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,6 @@ module "ocean-aws-k8s-vng_stateless" {
   #ami_id = "" # Can change the AMI
 
   labels = [{key="type",value="stateless"}]
-  #taints = [{key="type",value="stateless",effect="NoSchedule"}]
-  
-  tags = {CreatedBy = "terraform"} #Addition Tags
 }
 
 ## Create additional Ocean Virtual Node Group (launchspec) ##
@@ -39,7 +36,6 @@ module "ocean-aws-k8s-vng_gpu" {
   ocean_id = module.ocean-aws-k8s.ocean_id
   
   name = "gpu"  # Name of VNG in Ocean
-  #ami_id = "" # Can chang  # Add Labels or taints
   
   labels = [{key="type",value="gpu"}]
   taints = [{key="type",value="gpu",effect="NoSchedule"}]
@@ -65,7 +61,7 @@ module "ocean-controller" {
 
 | Name | Version |
 |------|---------|
-| spotinst/spotinst | >= 1.64.1 |
+| spotinst/spotinst | >= 1.78 |
 
 ## Modules
 * `ocean-aws-k8s` - Creates Ocean Cluster [Doc](https://registry.terraform.io/modules/spotinst/ocean-aws-k8s/spotinst/latest)

--- a/main.tf
+++ b/main.tf
@@ -11,28 +11,9 @@ resource "spotinst_ocean_aws_launch_spec" "nodegroup" {
   preferred_spot_types = var.preferred_spot_types
   root_volume_size     = length(var.block_device_mappings) == 0 ? var.root_volume_size : null
 
-
-  # Required tags
-  tags {
-    key   = "spotinst:ocean:launchspec:name"
-    value = var.name
-  }
-  tags {
-    key   = "kubernetes.io/cluster/${var.cluster_name}"
-    value = "owned"
-  }
-
-  # Default Tags
+  #Optional, tags will be inherited by the default launchspec configured in the ocean_aws resource
   dynamic "tags" {
-    for_each = data.aws_default_tags.default_tags.tags
-    content {
-      key   = tags.key
-      value = tags.value
-    }
-  }
-
-  dynamic "tags" {
-    for_each = var.tags == null ? {Name = "${var.cluster_name}-ocean-cluster-node"} : var.tags
+    for_each = var.tags == null ? {} : var.tags
     content {
       key   = tags.key
       value = tags.value

--- a/variables.tf
+++ b/variables.tf
@@ -56,7 +56,7 @@ variable "root_volume_size" {
 variable "tags" {
   type        = map(string)
   default     = null
-  description = "Tags to be added to resources"
+  description = "(Optional) Tags by default will be inherited from the ocean_aws resource. If set this will overwrite all tags and not add additional tags to those already configured."
 }
 variable "associate_public_ip_address" {
   type        = bool


### PR DESCRIPTION
Solve issue #10 

- Remove all tags from VNG module. Tags are inherited from default launchspec in ocean_aws resource. 
- Note: If tags are used they will replace default tags. The owned tag for EKS is required and will need to be added along with any additional desired tags. 