### PR TITLE
fix typo in  "force_delete" varaible description

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -186,7 +186,7 @@ variable "initial_nodes" {
 variable "force_delete" {
   type        = bool
   default     = false
-  description = "When set to true, delete even if it is the last Virtual Node Group (also, the default Virtual Node Group must be configured with useAsTemlateOnly = true). Should be set at creation or update, but will be used only at deletion."
+  description = "When set to true, delete even if it is the last Virtual Node Group (also, the default Virtual Node Group must be configured with useAsTemplateOnly = true). Should be set at creation or update, but will be used only at deletion."
 }
 variable "delete_nodes" {
   type        = bool


### PR DESCRIPTION
Typo in `force_delete` description.  
`useAsTemlateOnly` >> `useAsTemplateOnly`