### PR TITLE
feat: added instance_metadata_options block & variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,11 @@ resource "spotinst_ocean_aws_launch_spec" "nodegroup" {
   associate_public_ip_address = var.associate_public_ip_address
   restrict_scale_down         = var.restrict_scale_down
 
+  instance_metadata_options {
+    http_tokens                 = var.http_tokens
+    http_put_response_hop_limit = var.http_put_response_hop_limit
+  }
+
   dynamic "labels" {
     for_each = var.labels == null ? [] : var.labels
     content {

--- a/main.tf
+++ b/main.tf
@@ -109,7 +109,7 @@ resource "spotinst_ocean_aws_launch_spec" "nodegroup" {
 
   delete_options {
     force_delete = var.force_delete
-    delete_nodes=var.delete_nodes
+    delete_nodes = var.delete_nodes
   }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,33 @@ variable "restrict_scale_down" {
   default     = null
   description = "When set to True, nodes will be treated as if all pods running have the restrict-scale-down label. Therefore, Ocean will not scale nodes down unless empty."
 }
+
+## instance_metadata_options ##
+# Ocean instance metadata options object for IMDSv2
+
+variable "http_tokens" {
+  type        = string
+  default     = null
+  description = "Determines if a signed token is required or not. Valid values: 'optional' or 'required'."
+
+  validation {
+    condition     = contains(["optional", "required"], var.http_tokens)
+    error_message = "Valid values: 'optional' or 'required'."
+  }
+}
+
+variable "http_put_response_hop_limit" {
+  type        = number
+  default     = null
+  description = "An integer from 1 through 64. The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further the instance metadata requests can travel."
+
+  validation {
+    condition     = var.http_put_response_hop_limit >= 1 && var.http_put_response_hop_limit <= 64
+    error_message = "Valid values: integer value between 1 and 64."
+  }
+}
+###################
+
 variable "labels" {
   type = list(object({
     key   = string


### PR DESCRIPTION
Adds the ability to specify instance metadata options to the VNG resource.
Ran `terraform fmt` as well