### PR TITLE
fix/codeowners--SPOTHDESKC-4420: change codeowners of repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 # the repo. Unless a later match takes precedence,
 # "frontend-code-reviewers" team members will be requested for
 # review when someone opens a pull request.
-*                 @spotinst/sig-reviewers
+*                 @spotinst/sig-terraform-reviewres


### PR DESCRIPTION
since anurag's team is now owner of the repo

# Jira Ticket
[SPOTHDESKC-4420](https://spotinst.atlassian.net/browse/SPOTHDESKC-4420)

[SPOTHDESKC-4420]: https://spotinst.atlassian.net/browse/SPOTHDESKC-4420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ