### PR TITLE
Change version constraints for spotinst/spotinst provider to allow bo…

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     spotinst = {
       source  = "spotinst/spotinst"
-      version = ">= 1.191.0"
+      version = "~> 1.191"
     }
   }
 }


### PR DESCRIPTION
…th new patch and minor versions

Previous constraints only allowed new patch versions of the provider to be used, limiting use of new features from 1.192 and above. Fixes https://github.com/spotinst/terraform-spotinst-ocean-aws-k8s-vng/issues/51

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
